### PR TITLE
fix endless loop, skin & js urls, sessions

### DIFF
--- a/app/code/community/Studioforty9/Ngrok/Model/Session.php
+++ b/app/code/community/Studioforty9/Ngrok/Model/Session.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @author https://github.com/EObukhovsky
+ */
+class Studioforty9_Ngrok_Model_Session extends Mage_Core_Model_Session
+{
+    /**
+     * Skip form key validation on adminhtml login
+     *
+     * @param null|string $formKey
+     * @return bool
+     */
+    public function validateFormKey($formKey)
+    {
+        if (false === strpos($_SERVER['HTTP_X_ORIGINAL_HOST'], 'ngrok.io')
+            && debug_backtrace()[1]['function'] == 'actionPreDispatchAdmin') {
+            return true;
+        }
+        return parent::validateFormKey($formKey);
+    }
+}

--- a/app/code/community/Studioforty9/Ngrok/etc/config.xml
+++ b/app/code/community/Studioforty9/Ngrok/etc/config.xml
@@ -23,6 +23,7 @@
             <core>
                 <rewrite>
                     <store>Studioforty9_Ngrok_Model_Store</store>
+                    <session>Studioforty9_Ngrok_Model_Session</session>
                 </rewrite>
             </core>
         </models>


### PR DESCRIPTION
I run magento on laravel homesteage box. 
apache2
php 7.0
I noticed that 
($_SERVER['HTTP_HOST']) is equal to  site.local URL
so I changed it to HTTP_X_ORIGINAL_HOST and got an endless redirect loop.
Get rid of them using debug_backtrace() checks.
With this version I also can't reproduse #1 and #2 issues.
+ fix for admin login